### PR TITLE
update precommit to stop removing trailing whitespace from md docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     rev: v4.0.1
     hooks:
     -   id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
     -   id: end-of-file-fixer
     -   id: no-commit-to-branch
         args: [--branch, develop, --branch, master, --pattern, release/.*]


### PR DESCRIPTION
Updating the pre-commit config to modify the trailing whitespaces hook to exclude markdown documents. 
(from https://github.com/uc-cdis/my-BRH-documentation/pull/new/update-precommit-config)